### PR TITLE
Create dim_instructors model

### DIFF
--- a/models/marts/dim_instructors.sql
+++ b/models/marts/dim_instructors.sql
@@ -1,0 +1,25 @@
+with instructors as (
+
+    select *
+    from {{ ref('stg_instructors') }}
+
+),
+
+final as (
+
+    select
+        instructor_id,
+        instructor_first_name,
+        instructor_last_name,
+
+        concat(instructor_first_name, ' ', instructor_last_name) as instructor_name,
+
+        speciality,
+        club_location
+
+    from instructors
+
+)
+
+select *
+from final

--- a/models/marts/dim_instructors.yml
+++ b/models/marts/dim_instructors.yml
@@ -1,0 +1,37 @@
+version: 2
+
+models:
+  - name: dim_instructors
+    description: "Final instructor dimension with one row per instructor."
+
+    columns:
+      - name: instructor_id
+        description: "Unique identifier for each instructor."
+        tests:
+          - not_null
+          - unique
+
+      - name: instructor_first_name
+        description: "Instructor first name."
+        tests:
+          - not_null
+
+      - name: instructor_last_name
+        description: "Instructor last name."
+        tests:
+          - not_null
+
+      - name: instructor_name
+        description: "Full instructor name."
+        tests:
+          - not_null
+
+      - name: speciality
+        description: "Instructor speciality."
+        tests:
+          - not_null
+
+      - name: club_location
+        description: "Instructor club location."
+        tests:
+          - not_null


### PR DESCRIPTION
Ticket - https://github.com/cbfacademy/fittrack_analytics/issues/28

**Created dim_instructors as the final instructor dimension.**

**What I changed**

- Selected clean instructor fields from stg_instructors

**Included:**


- instructor name
- speciality
- club location
- Preserved one row per instructor

**Tests**
Added dim_instructors.yml with column tests for key descriptive fields